### PR TITLE
flask-swagger 0.2.14: Rebuild

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,8 +2,3 @@ pbp_autopublish: false
 
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/werkzeug-feedstock/pr12/8d990c6
-  - https://staging.continuum.io/prefect/fs/blinker-feedstock/pr9/270c993
-  - https://staging.continuum.io/prefect/fs/flask-feedstock/pr13/1e27f78

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+pbp_autopublish: false
+
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/werkzeug-feedstock/pr12/8d990c6
+  - https://staging.continuum.io/prefect/fs/blinker-feedstock/pr9/270c993
+  - https://staging.continuum.io/prefect/fs/flask-feedstock/pr13/1e27f78

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,14 +6,13 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: b4085f5bc36df4c20b6548cd1413adc9cf35719b0f0695367cd542065145294d
 
 build:
   noarch: python
-  number: 2
-  script: python -m pip install --no-deps --ignore-installed .
+  number: 3
+  script: {{PYTHON}} -m pip install --no-deps --no-build-isolation --ignore-installed . -vv
 
   entry_points:
     - flaskswagger=build_swagger_spec:run
@@ -23,26 +22,30 @@ requirements:
     - pip
     - python
     - setuptools
+    - wheel
   run:
     - python
     - flask >=0.10
     - pyyaml >=5.1
 
 test:
-  commands:
-    - flaskswagger --help
-
   imports:
     - flask_swagger
+  requires:
+    - pip
+  commands:
+    - pip check
+    - flaskswagger --help
 
 about:
-  home: http://github.com/gangverk/flask-swagger
+  home: https://github.com/getsling/flask-swagger
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: 'Extract swagger specs from your flask project'
-
-  dev_url: https://github.com/gangverk/flask-swagger
+  summary: Extract swagger specs from your flask project
+  description: Extract swagger specs from your flask project
+  dev_url: https://github.com/getsling/flask-swagger
+  doc_url: https://github.com/getsling/flask-swagger
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6806](https://anaconda.atlassian.net/browse/PKG-6806)
- [Upstream repo](https://github.com/getsling/flask-swagger/tree/v0.2.14)
- requirements-tagged:
  - https://github.com/getsling/flask-swagger/blob/v0.2.14/setup.py


### Explanation of changes:

- Bump the build number to 3
- Add pip check

[PKG-6806]: https://anaconda.atlassian.net/browse/PKG-6806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ